### PR TITLE
User Gets Single Meal by ID

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,8 +4,9 @@ var path = require('path');
 var cookieParser = require('cookie-parser');
 var logger = require('morgan');
 
-var indexRouter = require('./routes/index');
-var foodsRouter = require('./routes/api/v1/foods');
+const indexRouter = require('./routes/index');
+const foodsRouter = require('./routes/api/v1/foods');
+const mealsRouter = require('./routes/api/v1/meals');
 
 var app = express();
 
@@ -21,6 +22,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', indexRouter);
 app.use('/api/v1/foods', foodsRouter);
+app.use('/api/v1/meals', mealsRouter);
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/migrations/20191009215319-create-meal-food.js
+++ b/migrations/20191009215319-create-meal-food.js
@@ -8,7 +8,7 @@ module.exports = {
         primaryKey: true,
         type: Sequelize.INTEGER
       },
-      foodId: {
+      FoodId: {
         type: Sequelize.INTEGER,
         allowNull: false,
         references: {
@@ -16,7 +16,7 @@ module.exports = {
           key: 'id'
         }
       },
-      mealId: {
+      MealId: {
         type: Sequelize.INTEGER,
         allowNull: false,
         references: {

--- a/models/food.js
+++ b/models/food.js
@@ -5,7 +5,7 @@ module.exports = (sequelize, DataTypes) => {
     calories: DataTypes.INTEGER
   }, {});
   Food.associate = function(models) {
-    Food.belongsToMany(models.Meal, { through: 'MealFoods', as: 'meals', foreignKey: 'FoodId', otherKey: 'MealId' });
+    Food.belongsToMany(models.Meal, { through: 'MealFoods', foreignKey: 'FoodId', otherKey: 'MealId' });
   };
   return Food;
 };

--- a/models/food.js
+++ b/models/food.js
@@ -5,7 +5,7 @@ module.exports = (sequelize, DataTypes) => {
     calories: DataTypes.INTEGER
   }, {});
   Food.associate = function(models) {
-    Food.belongsToMany(models.Meal, { through: 'MealFoods', as: 'meals', foreignKey: 'foodId', otherKey: 'mealId' });
+    Food.belongsToMany(models.Meal, { through: 'MealFoods', as: 'meals', foreignKey: 'FoodId', otherKey: 'MealId' });
   };
   return Food;
 };

--- a/models/meal.js
+++ b/models/meal.js
@@ -4,7 +4,7 @@ module.exports = (sequelize, DataTypes) => {
     name: DataTypes.STRING
   }, {});
   Meal.associate = function(models) {
-    Meal.belongsToMany(models.Food, { through: 'MealFoods', as: "foods", foreignKey: 'MealId', otherKey: "FoodId" });
+    Meal.belongsToMany(models.Food, { through: 'MealFoods', foreignKey: 'MealId', otherKey: "FoodId" });
   };
   return Meal;
 };

--- a/models/meal.js
+++ b/models/meal.js
@@ -4,7 +4,7 @@ module.exports = (sequelize, DataTypes) => {
     name: DataTypes.STRING
   }, {});
   Meal.associate = function(models) {
-    Meal.belongsToMany(models.Food, { through: 'MealFoods', as: "foods", foreignKey: 'mealId', otherKey: "foodId" });
+    Meal.belongsToMany(models.Food, { through: 'MealFoods', as: "foods", foreignKey: 'MealId', otherKey: "FoodId" });
   };
   return Meal;
 };

--- a/models/mealfood.js
+++ b/models/mealfood.js
@@ -1,7 +1,7 @@
 'use strict';
 module.exports = (sequelize, DataTypes) => {
   const MealFoods = sequelize.define('MealFoods', {
-    foodId: {
+    FoodId: {
       type: DataTypes.INTEGER,
       allowNull: false,
       references: {
@@ -9,7 +9,7 @@ module.exports = (sequelize, DataTypes) => {
         key: 'id'
       }
     },
-    mealId: {
+    MealId: {
       type: DataTypes.INTEGER,
       allowNull: false,
       references: {

--- a/routes/api/v1/foods.js
+++ b/routes/api/v1/foods.js
@@ -1,7 +1,8 @@
-var router = require('express').Router();
-var Food = require('../../../models').Food;
+const router = require('express').Router();
+const Food = require('../../../models').Food;
+const MealFoods = require('../../../models').MealFoods;
 
-router.get("/", function(req, res, next) {
+router.get("/", (req, res) => {
   res.setHeader("Content-type", "application/json")
 
   Food.findAll()
@@ -42,7 +43,7 @@ router.patch('/:id', (req, res) => {
   .catch(error => res.status(500).send(JSON.stringify(error)));
 });
 
-router.post("/", function(req, res) {
+router.post("/", (req, res) => {
   res.setHeader("Content-Type", "application/json");
   Food.create({
     name: req.body.name,
@@ -54,13 +55,17 @@ router.post("/", function(req, res) {
 
 router.delete('/:id', (req, res) => {
   res.setHeader("Content-Type", "application/json");
-  Food.destroy({where: {id: req.params.id}})
-  .then(row => {
-    if (row == 1) {
-      res.status(204).send()
-    } else {
-      res.status(404).send(JSON.stringify({error: "Food with ID(" + req.params.id + ") not found."}));
-    }
+  MealFoods.destroy({where: {FoodId: req.params.id}})
+  .then(() => {
+    Food.destroy({where: {id: req.params.id}})
+    .then(row => {
+      if (row == 1) {
+        res.status(204).send()
+      } else {
+        res.status(404).send(JSON.stringify({error: "Food with ID(" + req.params.id + ") not found."}));
+      }
+    })
+    .catch(error => res.status(500).send({error}));
   })
   .catch(error => res.status(500).send({error}));
 });

--- a/routes/api/v1/meals.js
+++ b/routes/api/v1/meals.js
@@ -14,7 +14,7 @@ router.get('/:id', (req, res) => {
     if(meal){
       res.status(200).send(JSON.stringify(meal));
     } else {
-      res.status(404).send(JSON.stringify({error: "Food with ID(" + req.params.id + ") not found."}));
+      res.status(404).send(JSON.stringify({error: "Meal with ID(" + req.params.id + ") not found."}));
     }
   })
   .catch(error => res.status(500).send(JSON.stringify(error)));

--- a/routes/api/v1/meals.js
+++ b/routes/api/v1/meals.js
@@ -1,0 +1,24 @@
+const router = require('express').Router();
+const models = require('../../../models');
+const Meal = models.Meal;
+const Food = models.Food;
+
+router.get('/:id', (req, res) => {
+  res.setHeader('Content-Type', 'application/json');
+  Meal.findOne({
+    where: {id: req.params.id},
+    include: [
+      {model: Food, through: {attributes: []}}
+    ]
+  }).then(meal => {
+    if(meal){
+      res.status(200).send(JSON.stringify(meal));
+    } else {
+      res.status(404).send(JSON.stringify({error: "Food with ID(" + req.params.id + ") not found."}));
+    }
+  })
+  .catch(error => res.status(500).send(JSON.stringify(error)));
+});
+
+module.exports = router;
+

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -88,8 +88,8 @@ afterAll(() => {
         await Food.create({ name: "bacon", calories: 500})
       ]
       let meal = await Meal.create({name: 'breakfast'});
-      await meal.addFoods(items);
-      let results = await meal.getFoods();
+      await meal.addFood(items);
+      let results = await meal.getFood();
       expect(results[0].name).toBe("hashbrowns")
       expect(results[0].calories).toBe(300)
       expect(results[1].name).toBe("bacon")

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -97,4 +97,25 @@ afterAll(() => {
       expect(results[1].name).not.toBe("potato chips")
     })
   });
+
+
+
+  describe("Meals", () => {
+    test('GET /api/v1/meals/:id Happy', () => {
+      return request(app).get('/api/v1/meals/3')
+      .then(rsp => {
+        expect(rsp.status).toBe(200);
+        expect(Object.keys(rsp.body)).toContain('name');
+        expect(Object.keys(rsp.body)).toContain('Food');
+      });
+    });
+
+    test('GET /api/v1/meals/:id Sad', () => {
+      return request(app).get('/api/v1/meals/9999')
+      .then(rsp => {
+        expect(rsp.status).toBe(404);
+        expect(rsp.body.error).toBe('Meal with ID(9999) not found.');
+      });
+    });
+  });
 })


### PR DESCRIPTION
Satisifies #19 

Adds GET /api/v1/meals/:id, returning the meal, with all associated foods.

Also, fixes DELETE /api/v1/foods/:id, by first deleting all associations from MealFoods that contain the food, so as to avoid deleting a key that's in use.

I had to change all instances of `mealId` and `foodId` to `MealId` and `FoodId` and I removed `as: "meals"` and `as: "foods"` to get `includes:` to work properly.